### PR TITLE
pymorphy3-dicts-uk 2.4.1.1.1663094765

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,3 @@
-aggregate_check: false
 upload_channels:
   - sk_test
 channels:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,4 @@
+aggregate_check: false
 upload_channels:
   - sk_test
 channels:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b3945a34136e193806cde657ba271d88a60761e75137c13d138a8d142a8d12ac
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
@@ -32,9 +32,14 @@ test:
 
 about:
   home: https://github.com/no-plagiarism/pymorphy3-dicts
+  dev_url: https://github.com/no-plagiarism/pymorphy3-dicts
+  doc_url: https://github.com/no-plagiarism/pymorphy3-dicts
   summary: Ukrainian dictionaries for pymorphy3
+  description: |
+    Ukrainian dictionaries for pymorphy3
   license: GPL-3.0-or-later
-  license_file: PLEASE_ADD_LICENSE_FILE
+  license_family: GPL
+  license_url: https://github.com/no-plagiarism/pymorphy3-dicts/blob/master/LICENSE
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
License: https://github.com/no-plagiarism/pymorphy3-dicts/blob/master/LICENSE
Requirements: https://github.com/no-plagiarism/pymorphy3-dicts/blob/master/cookiecutter-pymorphy3-dicts/%7B%7B%20cookiecutter.distribution_name%20%7D%7D/setup.py

Notes:
- the package is a dependency of `pymorph3` and it's needed for resolving this issue https://github.com/conda-forge/spacy-models-feedstock/issues/2